### PR TITLE
Fix bug: A second call to what cb2p() return does NOT match the first call

### DIFF
--- a/cb2p.js
+++ b/cb2p.js
@@ -29,15 +29,17 @@ module.exports = (function () {
 				}]);
 
 
+				var fnToCall = fn
 				if(fn) {
 					oThis = obj;
 					if(typeof fn !== 'function') {
-						fn = obj[fn];
+						fnToCall = obj[fn];
 					}
 				}else{
-					fn = obj;
+					fnToCall = obj;
 				}
-				return fn.apply(oThis, aP);
+
+				return fnToCall.apply(oThis, aP);
 			});
 		};
 

--- a/test/test.js
+++ b/test/test.js
@@ -217,7 +217,7 @@ $$QTest.asyncTest('obj.method.p2cb.this:', function (assert) {
 			})
 			.then(function(o){
 				assert.equal(o, 'OK#2', '[run2] should OK');
-				assert.ok(beforeCbIsCalled, '[run1] beforeCb should be called');
+				assert.ok(beforeCbIsCalled, '[run2] beforeCb should be called');
 			}, function(err){
 				assert.ok(false, '[run2] No error should be caught');
 			})

--- a/test/test.js
+++ b/test/test.js
@@ -178,6 +178,60 @@ $$QTest.asyncTest('obj.method.p2cb :', function (assert) {
 
 });
 
+$$QTest.asyncTest('obj.method.p2cb.this:', function (assert) {
+	var obj = {
+		foo: function(id, beforeCb, cb){
+			beforeCb.call(this)
+			cb.call(this, null, 'OK#' + id)
+		}
+	}
+	
+	obj.foo = $$cb2p(obj.foo)
+
+	var run1 = function(){
+		var beforeCbIsCalled = false
+		obj.foo(1, function(){
+				beforeCbIsCalled = true
+				assert.ok(this === obj, '[run1] this should equal obj');
+			})
+			.then(function(o){
+				assert.equal(o, 'OK#1', '[run1] should OK');
+				assert.ok(beforeCbIsCalled, '[run1] beforeCb should be called');
+			}, function(err){
+				assert.ok(false, '[run1] No error should be caught');
+			})
+			.catch(function(err){
+				console.error(err)
+				assert.ok(false, '[run1]  No error should be caught2');
+			})
+			.then(function(){
+				run2()
+			});
+	}
+
+	var run2 = function(){
+		var beforeCbIsCalled = false
+		obj.foo(2, function(){
+				beforeCbIsCalled = true
+				assert.ok(this === obj, '[run2] this should equal obj');
+			})
+			.then(function(o){
+				assert.equal(o, 'OK#2', '[run2] should OK');
+				assert.ok(beforeCbIsCalled, '[run1] beforeCb should be called');
+			}, function(err){
+				assert.ok(false, '[run2] No error should be caught');
+			})
+			.catch(function(err){
+				console.error(err)
+				assert.ok(false, '[run2]  No error should be caught2');
+			})
+			.then(function(){
+				$$QTest.start();
+			});
+	}
+
+	run1()
+});
 
 $$QTest.asyncTest('obj.method.setBackFun :', function (assert) {
 


### PR DESCRIPTION
fix this issue: <https://github.com/purplestone/cb2p/issues/1>
